### PR TITLE
Functional example app

### DIFF
--- a/examples/app.php
+++ b/examples/app.php
@@ -1,15 +1,28 @@
 <?php
     // See the accompanying README for how to use Fitzgerald!
 
-    include('../lib/fitzgerald.php');
-
     class Application extends Fitzgerald {
+
         // Define your controller methods, remembering to return a value for the browser!
+        public function __construct( $options = array() )
+        {
+            parent::__construct($options);
+        }
+
+        public function get_index()
+        {
+            return $this->render('index');
+        }
     }
 
-    $app = new Application();
+    // Define root app path to get your views, only needed when you have
+    // Fitzgerald library on another level outside from your app folder.
+    // Notice trailing slash for the path
+    $params = array('root' => realpath(__DIR__).'/');
+
+    $app = new Application($params);
 
     // Define your url mappings. Take advantage of placeholders and regexes for safety.
+    $app->get('/', 'get_index');
 
     $app->run();
-?>

--- a/examples/public/index.php
+++ b/examples/public/index.php
@@ -1,3 +1,4 @@
 <?php
+	// Include Fitzgerald framework and app class.
+	include('../../lib/fitzgerald.php');
     include('../app.php');
-?>

--- a/examples/public/index.php
+++ b/examples/public/index.php
@@ -1,4 +1,4 @@
 <?php
-	// Include Fitzgerald framework and app class.
-	include('../../lib/fitzgerald.php');
+    // Include Fitzgerald framework and app class.
+    include('../../lib/fitzgerald.php');
     include('../app.php');

--- a/examples/views/index.php
+++ b/examples/views/index.php
@@ -1,0 +1,1 @@
+<h1>Welcome to Fitzgerald!</h1>


### PR DESCRIPTION
When I cloned the repo, I noticed example causes some errors. The first one fixed on #3 and the others were fixed on example app files.

Modifications to get functional example app.
- `include` instruction for `lib/fitzgerald` moved to `public/index.php` because it was causing problems resolving path to file and calling `../../lib/fitzgerald.php` on `app.php` may cause some confusions.
- Provide `root` param to locate working path for views folder, explanation included.
- Delete close php tags `?>` since pure php files does not need close tags.
- Add `index` view for example purpposes
